### PR TITLE
merge-link: update vue merge link wrapper to pass in tenant config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # vue-merge-link
 
 See documentation at https://merge.dev/docs/linking-flow/get-started.
+
+When updating this repo, bump the version number in `package.json` according to this semantic versioning scheme: https://docs.npmjs.com/about-semantic-versioning

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/vue-merge-link",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/merge-link.ssr.js",
   "browser": "dist/merge-link.esm.js",

--- a/src/merge-link.vue
+++ b/src/merge-link.vue
@@ -17,6 +17,7 @@ export default {
     onReady: Function,
     onSuccess: Function,
     onExit: Function,
+    tenantConfig: Object,
   },
   created() {
     this.loadScript("https://cdn.merge.dev/initialize.js")
@@ -30,6 +31,7 @@ export default {
     onScriptLoaded() {
       window.MergeLink.initialize({
         linkToken: this.linkToken,
+        tenantConfig: this.tenantConfig,
         shouldSendTokenOnSuccessfulLink: this.shouldSendTokenOnSuccessfulLink,
         onExit: this.onExit,
         onReady: this.onReady,


### PR DESCRIPTION
## Description of the change

We allow customer to pass in a tenant config to useMergeLink and thus our initialize.js script when using the vue wrapper.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://app.asana.com/0/1201984807087545/1202010185492646

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
